### PR TITLE
chore(deps): bumps projen form 0.8.0 to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "jest": "^26.6.3",
     "jest-junit": "^12",
-    "projen": "^0.8.0",
+    "projen": "^0.9.0",
     "standard-version": "^9.0.0"
   },
   "peerDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4428,10 +4428,10 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-projen@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/projen/-/projen-0.8.0.tgz#9035265a7acd297707ab4771a9ba6936932f1951"
-  integrity sha512-4ybVDnSsV9SzHKHpwX9EkQ5CsCJeaQjH4rmlmfYMpcfw/YBF42JauwyZe7y3uTumOd7HYPpj5/Cz0SiUZc+Acg==
+projen@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/projen/-/projen-0.9.0.tgz#6b6b7d5543653c747becdd7294d4cf4229b8772b"
+  integrity sha512-N6wy+vkXPBPzK0CF0vMUmGqQFxISqZamyMw2uhR+XPPgnBKUhPylcxqZSj+qFPlbAxORyn5PqRR4BO6baCYa7w==
   dependencies:
     "@iarna/toml" "^2.2.5"
     chalk "^4.1.0"


### PR DESCRIPTION
which includes the readme.md fix
